### PR TITLE
adding timeout for long requests

### DIFF
--- a/bin/linkto_bot
+++ b/bin/linkto_bot
@@ -128,7 +128,8 @@ if __name__ == "__main__":
         options['depth'],
         options['crawl_delay'],
         options['exclude_external_urls'],
-        options['exclude_url_patterns']
+        options['exclude_url_patterns'],
+        options['request_timeout']
     )
 
     out = {

--- a/config_default.yml
+++ b/config_default.yml
@@ -7,6 +7,7 @@ bot:
     logfile: linkto.log
     exclude_external_urls: True
     crawl_delay: 1
+    request_timeout: 60
 
     # list of regular expressions describing urls not to visit
     exclude_url_patterns:


### PR DESCRIPTION
added a timeout for requests. default is a very unreasonable 60 seconds. if we dont get a response after 60 seconds, we retry the request and wait another 60 seconds. after that we raise an error.

request timeout error messages should look like:
```
requests.exceptions.ReadTimeout: HTTPConnectionPool(host='abc', port=8888): Read timed out. (read timeout=5)
```

need to update the configuration file's bot section with a new key named `request_timeout`. set the value to an integer representing the number of seconds to wait for a response to an HTTP request.

Connected to #2 